### PR TITLE
Update to upstream v3.5

### DIFF
--- a/caPutLogApp/caPutLogTask.c
+++ b/caPutLogApp/caPutLogTask.c
@@ -359,24 +359,32 @@ static void val_min(VALUE *pres, const VALUE *pa, const VALUE *pb, short type)
 {
     switch (type) {
     case DBR_CHAR:
-        pres->v_char = min(pa->v_char, pb->v_char);
+        pres->v_int8 = min(pa->v_int8, pb->v_int8);
         return;
     case DBR_UCHAR:
-        pres->v_uchar = min(pa->v_uchar, pb->v_uchar);
+        pres->v_uint8 = min(pa->v_uint8, pb->v_uint8);
         return;
     case DBR_SHORT:
-        pres->v_short = min(pa->v_short, pb->v_short);
+        pres->v_int16 = min(pa->v_int16, pb->v_int16);
         return;
     case DBR_USHORT:
     case DBR_ENUM:
-        pres->v_ushort = min(pa->v_ushort, pb->v_ushort);
+        pres->v_uint16 = min(pa->v_uint16, pb->v_uint16);
         return;
     case DBR_LONG:
-        pres->v_long = min(pa->v_long, pb->v_long);
+        pres->v_int32 = min(pa->v_int32, pb->v_int32);
         return;
     case DBR_ULONG:
-        pres->v_ulong = min(pa->v_ulong, pb->v_ulong);
+        pres->v_uint32 = min(pa->v_uint32, pb->v_uint32);
         return;
+#ifdef DBR_INT64
+    case DBR_INT64:
+        pres->v_int64 = min(pa->v_int64, pb->v_int64);
+        return;
+    case DBR_UINT64:
+        pres->v_uint64 = min(pa->v_uint64, pb->v_uint64);
+        return;
+#endif
     case DBR_FLOAT:
         pres->v_float = min(pa->v_float, pb->v_float);
         return;
@@ -390,24 +398,32 @@ static void val_max(VALUE *pres, const VALUE *pa, const VALUE *pb, short type)
 {
     switch (type) {
     case DBR_CHAR:
-        pres->v_char = max(pa->v_char, pb->v_char);
+        pres->v_int8 = max(pa->v_int8, pb->v_int8);
         return;
     case DBR_UCHAR:
-        pres->v_uchar = max(pa->v_uchar, pb->v_uchar);
+        pres->v_uint8 = max(pa->v_uint8, pb->v_uint8);
         return;
     case DBR_SHORT:
-        pres->v_short = max(pa->v_short, pb->v_short);
+        pres->v_int16 = max(pa->v_int16, pb->v_int16);
         return;
     case DBR_USHORT:
     case DBR_ENUM:
-        pres->v_ushort = max(pa->v_ushort, pb->v_ushort);
+        pres->v_uint16 = max(pa->v_uint16, pb->v_uint16);
         return;
     case DBR_LONG:
-        pres->v_long = max(pa->v_long, pb->v_long);
+        pres->v_int32 = max(pa->v_int32, pb->v_int32);
         return;
     case DBR_ULONG:
-        pres->v_ulong = max(pa->v_ulong, pb->v_ulong);
+        pres->v_uint32 = max(pa->v_uint32, pb->v_uint32);
         return;
+#ifdef DBR_INT64
+    case DBR_INT64:
+        pres->v_int64 = max(pa->v_int64, pb->v_int64);
+        return;
+    case DBR_UINT64:
+        pres->v_uint64 = max(pa->v_uint64, pb->v_uint64);
+        return;
+#endif
     case DBR_FLOAT:
         pres->v_float = max(pa->v_float, pb->v_float);
         return;
@@ -424,58 +440,34 @@ static int val_equal(const VALUE *pa, const VALUE *pb, short type)
 {
     switch (type) {
     case DBR_CHAR:
-        return (pa->v_char == pb->v_char);
+        return (pa->v_int8 == pb->v_int8);
     case DBR_UCHAR:
-        return (pa->v_uchar == pb->v_uchar);
+        return (pa->v_uint8 == pb->v_uint8);
     case DBR_SHORT:
-        return (pa->v_short == pb->v_short);
+        return (pa->v_int16 == pb->v_int16);
     case DBR_USHORT:
     case DBR_ENUM:
-        return (pa->v_ushort == pb->v_ushort);
+        return (pa->v_uint16 == pb->v_uint16);
     case DBR_LONG:
-        return (pa->v_long == pb->v_long);
+        return (pa->v_int32 == pb->v_int32);
     case DBR_ULONG:
-        return (pa->v_ulong == pb->v_ulong);
+        return (pa->v_uint32 == pb->v_uint32);
+#ifdef DBR_INT64
+    case DBR_INT64:
+        return (pa->v_int64 == pb->v_int64);
+    case DBR_UINT64:
+        return (pa->v_uint64 == pb->v_uint64);
+#endif
     case DBR_FLOAT:
         return (pa->v_float == pb->v_float);
     case DBR_DOUBLE:
         return (pa->v_double == pb->v_double);
-    default:
+    case DBR_STRING:
         return (0==strcmp(pa->v_string, pb->v_string));
-    }
-}
-
-#if 0
-#define cmp(a,b) (((a) < (b)) ? (-1) : (((a) > (b)) ? (+1) : 0))
-
-/*
- * val_cmp(): compare two VALUEs for equality(0), smaller(-1) or larger(+1)
- */
-static int val_cmp(const VALUE *pa, const VALUE *pb, short type)
-{
-    switch (type) {
-    case DBR_CHAR:
-        return cmp(pa->v_char, pb->v_char);
-    case DBR_UCHAR:
-        return cmp(pa->v_uchar, pb->v_uchar);
-    case DBR_SHORT:
-        return cmp(pa->v_short, pb->v_short);
-    case DBR_USHORT:
-    case DBR_ENUM:
-        return cmp(pa->v_ushort, pb->v_ushort);
-    case DBR_LONG:
-        return cmp(pa->v_long, pb->v_long);
-    case DBR_ULONG:
-        return cmp(pa->v_ulong, pb->v_ulong);
-    case DBR_FLOAT:
-        return cmp(pa->v_float, pb->v_float);
-    case DBR_DOUBLE:
-        return cmp(pa->v_double, pb->v_double);
     default:
-        return strcmp(pa->v_string, pb->v_string);
+        return 0;
     }
 }
-#endif
 
 /*
  * val_assign(): assign src VALUE to dst VALUE
@@ -484,24 +476,32 @@ static void val_assign(VALUE *dst, const VALUE *src, short type)
 {
     switch (type) {
     case DBR_CHAR:
-        dst->v_char = src->v_char;
+        dst->v_int8 = src->v_int8;
         break;
     case DBR_UCHAR:
-        dst->v_uchar = src->v_uchar;
+        dst->v_uint8 = src->v_uint8;
         break;
     case DBR_SHORT:
-        dst->v_short = src->v_short;
+        dst->v_int16 = src->v_int16;
         break;
     case DBR_USHORT:
     case DBR_ENUM:
-        dst->v_ushort = src->v_ushort;
+        dst->v_uint16 = src->v_uint16;
         break;
     case DBR_LONG:
-        dst->v_long = src->v_long;
+        dst->v_int32 = src->v_int32;
         break;
     case DBR_ULONG:
-        dst->v_ulong = src->v_ulong;
+        dst->v_uint32 = src->v_uint32;
         break;
+#ifdef DBR_INT64
+    case DBR_INT64:
+        dst->v_int64 = src->v_int64;
+        break;
+    case DBR_UINT64:
+        dst->v_uint64 = src->v_uint64;
+        break;
+#endif
     case DBR_FLOAT:
         dst->v_float = src->v_float;
         break;
@@ -523,18 +523,18 @@ static int val_to_string(char *pbuf, size_t buflen, const VALUE *pval, short typ
        /* CHAR and UCHAR are typically used as SHORTSHORT,
 	* so avoid mounting NULL-bytes into the string
 	*/
-        return epicsSnprintf(pbuf, buflen, "%d", (int)pval->v_uchar);
+        return epicsSnprintf(pbuf, buflen, "%d", (int)pval->v_uint8);
     case DBR_UCHAR:
-        return epicsSnprintf(pbuf, buflen, "%d", (int)pval->v_uchar);
+        return epicsSnprintf(pbuf, buflen, "%d", (int)pval->v_uint8);
     case DBR_SHORT:
-        return epicsSnprintf(pbuf, buflen, "%hd", pval->v_short);
+        return epicsSnprintf(pbuf, buflen, "%hd", pval->v_int16);
     case DBR_USHORT:
     case DBR_ENUM:
-        return epicsSnprintf(pbuf, buflen, "%hu", pval->v_ushort);
+        return epicsSnprintf(pbuf, buflen, "%hu", pval->v_uint16);
     case DBR_LONG:
-        return epicsSnprintf(pbuf, buflen, "%ld", pval->v_long);
+        return epicsSnprintf(pbuf, buflen, "%ld", (long)pval->v_int32);
     case DBR_ULONG:
-        return epicsSnprintf(pbuf, buflen, "%lu", pval->v_ulong);
+        return epicsSnprintf(pbuf, buflen, "%lu", (unsigned long)pval->v_uint32);
     case DBR_FLOAT:
         return epicsSnprintf(pbuf, buflen, "%g", pval->v_float);
     case DBR_DOUBLE:

--- a/caPutLogApp/caPutLogTask.h
+++ b/caPutLogApp/caPutLogTask.h
@@ -13,14 +13,18 @@ extern "C" {
 #define MAX_HOSTID_SIZE 32
 
 typedef union {
-    char            v_char;
-    unsigned char   v_uchar;
-    short           v_short;
-    unsigned short  v_ushort;
-    long            v_long;
-    unsigned long   v_ulong;
-    float           v_float;
-    double          v_double;
+    epicsInt8       v_int8;
+    epicsUInt8      v_uint8;
+    epicsInt16      v_int16;
+    epicsUInt16     v_uint16;
+    epicsInt32      v_int32;
+    epicsUInt32     v_uint32;
+#ifdef DBR_INT64
+    epicsInt64      v_int64;
+    epicsUInt64     v_uint64;
+#endif
+    epicsFloat32    v_float;
+    epicsFloat64    v_double;
     char            v_string[MAX_STRING_SIZE];
 } VALUE;
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+caputlog (3.5-1) unstable; urgency=medium
+
+  * Imported Upstream version 3.5
+  * Fixes linking error against Base 3.15
+
+ -- Daron Chabot <chabot@frib.msu.edu>  Tue, 17 May 2016 11:40:45 -0400
+
 caputlog (3.4-3) unstable; urgency=medium
 
   * remove missing and unneeded include tsDefs.h

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: extra
 Maintainer: Michael Davidsaver <mdavidsaver@gmail.com>
 Build-Depends: debhelper (>= 7.0.50~), epics-debhelper (>= 8.14~),
-               epics-dev (>= 3.14.11-2),
+               epics-dev (>= 3.15.3),
                python-sphinx,
                rtems-epics-mvme2100,
                rtems-epics-mvme2307,

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ X-Epics-Targets: .*
 Standards-Version: 3.9.6
 Homepage: http://www-csr.bessy.de/control/SoftDist/caPutLog/
 
-Package: libcaputlog3.4
+Package: libcaputlog3.5
 Architecture: any
 Section: libs
 Depends: ${shlibs:Depends}, ${misc:Depends}
@@ -25,7 +25,7 @@ Description: Logging of CA write operations
 Package: epics-caputlog-dev
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
-         libcaputlog3.4 (= ${binary:Version}),
+         libcaputlog3.5 (= ${binary:Version}),
          libjs-jquery, libjs-underscore,
 Description: Logging of CA write operations
  .

--- a/debian/libcaputlog3.4.lintian-overrides
+++ b/debian/libcaputlog3.4.lintian-overrides
@@ -1,4 +1,0 @@
-# upstream name has caps...
-libcaputlog3.4: package-name-doesnt-match-sonames libcaPutLog3.4
-# symlink is in a different diretory
-libcaputlog3.4: dev-pkg-without-shlib-symlink

--- a/debian/libcaputlog3.5.lintian-overrides
+++ b/debian/libcaputlog3.5.lintian-overrides
@@ -1,0 +1,4 @@
+# upstream name has caps...
+libcaputlog3.5: package-name-doesnt-match-sonames libcaPutLog3.5
+# symlink is in a different diretory
+libcaputlog3.5: dev-pkg-without-shlib-symlink

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,8 @@ You can also `browse`_ through the latest changes in the repo.
 +---------+---------------+-----------------------------------+---------------+
 | Version | EPICS Release | Filename                          | Release Notes |
 +=========+===============+===================================+===============+
+|   3.5   | 3.14.12..3.15 | :download:`caPutLog-3.5.tar.gz`   | :ref:`R3-5`   |
++---------+---------------+-----------------------------------+---------------+
 |   3.4   |   3.14.12     | :download:`caPutLog-3.4.tar.gz`   | :ref:`R3-4`   |
 +---------+---------------+-----------------------------------+---------------+
 |  3.3.3  |   3.14.12     | :download:`caPutLog-3.3.3.tar.gz` | :ref:`R3-3-3` |
@@ -46,8 +48,6 @@ You can also `browse`_ through the latest changes in the repo.
 +---------+---------------+-----------------------------------+---------------+
 |   3.0   |   3.14.8.2    | :download:`caPutLog-3.0.tar.gz`   | n/a           |
 +---------+---------------+-----------------------------------+---------------+
-
-All versions above should work with base 3.14.8.2 and newer.
 
 
 Setup
@@ -170,9 +170,6 @@ If you have any problems with this module, send me (`Ben Franksen`_) a mail.
 
 .. _Ben Franksen: mailto:benjamin.franksen@bessy.de
 .. _darcs: http://www.darcs.net/
-.. _caPutLog-3.0.tar.gz: caPutLog-3.0.tar.gz
-.. _caPutLog-3.1.tar.gz: caPutLog-3.1.tar.gz
-.. _caPutLog-3.2.tar.gz: caPutLog-3.2.tar.gz
 .. _HZB: http://www.helmholtz-berlin.de/
 .. _EPICS: http://www.aps.anl.goc/epics/
 .. _browse: http://www-csr.bessy.de/cgi-bin/darcsweb.cgi?r=caPutLog;a=summary

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,6 +1,19 @@
 Release Notes
 =============
 
+.. _R3-5:
+
+Changes since R3-4
+------------------
+
+  * removed dead code for val_cmp
+
+  * prepare for DBR_INT64 & fixed default clauses
+
+  * support base-3.15
+
+  * remove missing (in base-3.15) and unneeded include tsDefs.h
+
 .. _R3-4:
 
 Changes since R3-3-3


### PR DESCRIPTION
Fixes the linker error

```
/usr/lib/epics/lib/linux-x86_64/libcaPutLog.so: undefined reference to `dbNameOfPV'
collect2: error: ld returned 1 exit status
```

Note: `dbNameOfPV` does not exist in Base 3.15 (from 'dbAccess.c').