### PR TITLE
Use build profile to enable RTEMS cross build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+caputlog (3.5-2) unstable; urgency=medium
+
+  * Use build profile to enable RTEMS cross build
+
+ -- Martin Konrad <konrad@frib.msu.edu>  Fri, 14 Sep 2018 13:08:11 -0400
+
 caputlog (3.5-1) unstable; urgency=medium
 
   * Imported Upstream version 3.5

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: caputlog
 Section: devel
 Priority: extra
 Maintainer: Michael Davidsaver <mdavidsaver@gmail.com>
-Build-Depends: debhelper (>= 7.0.50~), epics-debhelper (>= 8.14~),
-               epics-dev (>= 3.14.12.3),
+Build-Depends: debhelper (>= 9.20141010), dpkg-dev (>= 1.17.14),
+               epics-debhelper (>= 8.14~), epics-dev (>= 3.14.12.3),
                python-sphinx,
-               rtems-epics-mvme2100,
-               rtems-epics-mvme2307,
-               rtems-epics-mvme3100,
-               rtems-epics-mvme5500,
+               rtems-epics-mvme2100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme2307 <pkg.epics-base.rtems>,
+               rtems-epics-mvme3100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme5500 <pkg.epics-base.rtems>,
 XS-Rtems-Build-Depends: rtems-epics
 X-Epics-Targets: .*
 Standards-Version: 3.9.6
@@ -33,6 +33,7 @@ Description: Logging of CA write operations
  IOC with the CA Put Log support.
 
 Package: rtems-caputlog-mvme2100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends}, epics-caputlog-dev (>= ${binary:Version}),
          epics-caputlog-dev (<< ${binary:Version}.1~), ${misc:Depends},
@@ -41,6 +42,7 @@ Description: Logging of CA write operations
  This package contains support for the MVME2100 PowerPC based VME SBC.
 
 Package: rtems-caputlog-mvme2307
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends}, epics-caputlog-dev (>= ${binary:Version}),
          epics-caputlog-dev (<< ${binary:Version}.1~), ${misc:Depends},
@@ -49,6 +51,7 @@ Description: Logging of CA write operations
  This package contains support for the MVME2307 PowerPC based VME SBC.
 
 Package: rtems-caputlog-mvme3100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends}, epics-caputlog-dev (>= ${binary:Version}),
          epics-caputlog-dev (<< ${binary:Version}.1~), ${misc:Depends},
@@ -57,6 +60,7 @@ Description: Logging of CA write operations
  This package contains support for the MVME3100 PowerPC based VME SBC.
 
 Package: rtems-caputlog-mvme5500
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends}, epics-caputlog-dev (>= ${binary:Version}),
          epics-caputlog-dev (<< ${binary:Version}.1~), ${misc:Depends},

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,2 +1,10 @@
 # for epics-debhelper
 caputlog source: unknown-field-in-dsc rtems-build-depends
+caputlog source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-caputlog-mvme2100
+caputlog source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-caputlog-mvme2307
+caputlog source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-caputlog-mvme3100
+caputlog source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-caputlog-mvme5500
+caputlog source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme2100 <pkg.epics-base.rtems>]
+caputlog source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme2307 <pkg.epics-base.rtems>]
+caputlog source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme3100 <pkg.epics-base.rtems>]
+caputlog source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme5500 <pkg.epics-base.rtems>]


### PR DESCRIPTION
This allows facilities that do not use RTEMS to get rid of the complexity of building this package's RTEMS dependencies. Set the environment variable `DEB_BUILD_PROFILES=pkg.epics-base.rtems` when compiling to enable the RTEMS build.